### PR TITLE
feat: install Vicinae on macOS

### DIFF
--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -19,6 +19,7 @@
       "google-chrome"
       "meetingbar"
       "hiddenbar"
+      "vicinae"
     ];
   };
   nix.enable = false;


### PR DESCRIPTION
Installs the pinned Vicinae Homebrew cask through nix-darwin. User-level hardening and Linux/Sway integration live in the companion Home Manager PR.\n\nCompanion Home Manager PR: https://github.com/na-son/flake/pull/6\n\nValidation:\n- alejandra .\n- nix eval .#darwinConfigurations.macos.config.system.build.toplevel.drvPath\n- confirmed darwinConfigurations.macos.config.homebrew.casks contains vicinae\n\nThe required NixOS evaluation remains blocked by the documented pre-existing vaapiIntel rename failure. Nothing was activated.